### PR TITLE
Fix duplicate ID issue due to usage of event.transaction.from instead of hash

### DIFF
--- a/src/mapping/l2.ts
+++ b/src/mapping/l2.ts
@@ -6,7 +6,7 @@ import {
 
 export function handleCommitment(event: NewCommitment): void {
   let entity = new Commitment(
-    event.transaction.from.toHex() + "-" + event.logIndex.toString()
+    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
   );
 
   entity.index = event.params.index;
@@ -21,7 +21,7 @@ export function handleCommitment(event: NewCommitment): void {
 
 export function handleNullifier(event: NewNullifier): void {
   let entity = new Nullifier(
-    event.transaction.from.toHex() + "-" + event.logIndex.toString()
+    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
   );
 
   entity.nullifier = event.params.nullifier;


### PR DESCRIPTION
Inorder to Create ID for Commitment the earlier implementaion used `event.transaction.from.toHex()+'-'+event.logIndex`

Which can have duplicates if the transaction from same address with same logIndex appears twice.

This PR changes the ID to use `event.transaction.hash` instead of `event.transaction.from`